### PR TITLE
Add map argument to PostcssCompiler

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,9 +5,9 @@ var CachingWriter = require('broccoli-caching-writer');
 var postcss = require('postcss');
 var CssSyntaxError = require('postcss/lib/css-syntax-error');
 
-function PostcssCompiler (inputTrees, inputFile, outputFile, plugins) {
+function PostcssCompiler (inputTrees, inputFile, outputFile, plugins, map) {
     if ( !(this instanceof PostcssCompiler) ) {
-        return new PostcssCompiler(inputTrees, inputFile, outputFile, plugins);
+        return new PostcssCompiler(inputTrees, inputFile, outputFile, plugins, map);
     }
 
     if ( !Array.isArray(inputTrees) ) {
@@ -19,6 +19,7 @@ function PostcssCompiler (inputTrees, inputFile, outputFile, plugins) {
     this.inputFile = inputFile;
     this.outputFile = outputFile;
     this.plugins = plugins || [];
+    this.map = map || {};
 }
 
 PostcssCompiler.prototype = Object.create(CachingWriter.prototype);
@@ -37,7 +38,7 @@ PostcssCompiler.prototype.updateCache = function (includePaths, destDir) {
     var options = {
         from: fromFilePath,
         to: toFilePath,
-        map: { inline: false }
+        map: this.map
     };
 
     this.plugins.forEach(function (plugin) {

--- a/test.js
+++ b/test.js
@@ -10,12 +10,16 @@ var plugins = [
         module: pe
     }
 ];
+var map = {
+    inline: false,
+    annotation: false
+};
 
-var outputTree = postcssCompiler(['fixture'], 'fixture.css', 'output.css', plugins);
+var outputTree = postcssCompiler(['fixture'], 'fixture.css', 'output.css', plugins, map);
 
 it('should process css', function () {
     return (new broccoli.Builder(outputTree)).build().then(function (dir) {
         var content = fs.readFileSync(path.join(dir.directory, 'output.css'), 'utf8');
-        assert.strictEqual(content.trim(), 'a:before { content: "test"; }\n\n/*# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbIi4uLy4uL2ZpeHR1cmUvZml4dHVyZS5jc3MiXSwibmFtZXMiOltdLCJtYXBwaW5ncyI6IkFBQUEsV0FBWSxnQkFBZ0IsRUFBRSIsImZpbGUiOiJvdXRwdXQuY3NzIiwic291cmNlc0NvbnRlbnQiOlsiYTo6YmVmb3JlIHsgY29udGVudDogXCJ0ZXN0XCI7IH1cbiJdfQ== */');
+        assert.strictEqual(content.trim(), 'a:before { content: "test"; }');
     });
 });

--- a/test.js
+++ b/test.js
@@ -16,6 +16,6 @@ var outputTree = postcssCompiler(['fixture'], 'fixture.css', 'output.css', plugi
 it('should process css', function () {
     return (new broccoli.Builder(outputTree)).build().then(function (dir) {
         var content = fs.readFileSync(path.join(dir.directory, 'output.css'), 'utf8');
-        assert.strictEqual(content.trim(), 'a:before { content: "test"; }\n\n/*# sourceMappingURL=output.css.map */');
+        assert.strictEqual(content.trim(), 'a:before { content: "test"; }\n\n/*# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbIi4uLy4uL2ZpeHR1cmUvZml4dHVyZS5jc3MiXSwibmFtZXMiOltdLCJtYXBwaW5ncyI6IkFBQUEsV0FBWSxnQkFBZ0IsRUFBRSIsImZpbGUiOiJvdXRwdXQuY3NzIiwic291cmNlc0NvbnRlbnQiOlsiYTo6YmVmb3JlIHsgY29udGVudDogXCJ0ZXN0XCI7IH1cbiJdfQ== */');
     });
 });


### PR DESCRIPTION
Allows users to specify the `map` option that postcss takes. Does not hardcode settings, and defaults to postcss' `map: true`.

External sourcemaps don't work because the [result.map](https://github.com/postcss/postcss#source-map) isn't handled [here](https://github.com/jeffjewiss/broccoli-postcss/blob/master/index.js#L48) I believe. To allow for external sourcemaps to work (besides the inline sourcemaps, which now work), this should be fixed as well.

See https://github.com/jeffjewiss/ember-cli-postcss/pull/3 