### PR TITLE
Use postcss-cssnext instead of cssnext in the example

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ An object of options to describe how Postcss should [handle source maps](https:/
 ```javascript
 /* Brocfile.js */
 var compileCSS = require('broccoli-postcss')
-var cssnext = require('cssnext')
+var cssnext = require('postcss-cssnext')
 
 var options =  {
   plugins: [


### PR DESCRIPTION
Requiring cssnext will throw an error when trying to build with broccoli.