### PR TITLE
Update README link to PostCSS sourcemap documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ A list of plugin objects to be used by Postcss (a minimum of 1 plugin is require
 Type: `object`
 Default: `{ inline: false, annotation: false }`
 
-An object of options to describe how Postcss should [handle source maps](https://github.com/postcss/postcss#source-map).
+An object of options to describe how Postcss should [handle source maps](https://github.com/postcss/postcss/blob/master/docs/source-maps.md).
 
 
 ## Example


### PR DESCRIPTION
I noticed that the PostCSS documentation for sourcemaps appears to have moved since it was linked to here. 

This PR provides the new link 😄. 