### PR TITLE
Support an array of PostCSS plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,30 @@ const outputTree = compileCSS(tree, options)
 
 Type: `array`
 
-A list of plugin objects to be used by Postcss (a minimum of 1 plugin is required). The supported object format is `module`: the plugin module itself, and `options`: an object of supported options for the given plugin.
+A list of plugin objects to be used by Postcss (a minimum of 1 plugin is required).
+
+There are two supported methods for defining plugins:
+
+1. Object form
+
+    ```javascript
+    plugins: [
+      {
+        module: require('some-plugin'),
+        options: { /* options for `some-plugin` */ }
+      }
+    ]
+    ```
+
+2. Function form
+
+    ```javascript
+    plugins: [
+      require('some-plugin')({ /* options for `some-plugin` */ }
+    ]
+    ```
+
+Note: additional options (defined below) that are merged with the individual plugin options are *only* supported for plugins defined in "object form".
 
 #### browsers
 

--- a/index.js
+++ b/index.js
@@ -52,8 +52,16 @@ PostcssFilter.prototype.processString = function (content, relativePath) {
   }
 
   opts.plugins.forEach((plugin) => {
-    let pluginOptions = assign(opts, plugin.options || {})
-    processor.use(plugin.module(pluginOptions))
+    let pluginInstance
+
+    if (plugin.module) {
+      let pluginOptions = assign(opts, plugin.options || {})
+      pluginInstance = plugin.module(pluginOptions)
+    } else {
+      pluginInstance = plugin
+    }
+
+    processor.use(pluginInstance)
   })
 
   return processor.process(content, opts)

--- a/test/index.js
+++ b/test/index.js
@@ -178,3 +178,25 @@ it('should throw an error if there is not at least 1 plugin', function () {
       assert.deepEqual(warnings, [])
     })
 })
+
+it('supports an array of plugin instances', function () {
+  let basicPlugin = basicPluginSet[0].module
+  let basicOptions = basicPluginSet[0].options
+  let pluginInstance = basicPlugin(basicOptions)
+
+  let outputTree = postcssFilter('fixture/success', {
+    plugins: [
+      pluginInstance
+    ],
+    map: true
+  })
+  let builder = new broccoli.Builder(outputTree) // eslint-disable-line no-new
+  postcssFilter.warningStream = warningStreamStub
+
+  return builder.build().then(function () {
+    let content = fs.readFileSync(path.join(builder.outputPath, 'fixture.css'), 'utf8')
+
+    assert.strictEqual(content.trim(), 'body {\n  color: #639\n}\n\n/*# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbImZpeHR1cmUuY3NzIl0sIm5hbWVzIjpbXSwibWFwcGluZ3MiOiJBQUFBO0VBQ0UsV0FBb0I7Q0FDckIiLCJmaWxlIjoiZml4dHVyZS5jc3MiLCJzb3VyY2VzQ29udGVudCI6WyJib2R5IHtcbiAgY29sb3I6IHJlYmVjY2FwdXJwbGVcbn1cbiJdfQ== */')
+    assert.deepEqual(warnings, [])
+  })
+})


### PR DESCRIPTION
Adds support for an array of PostCSS plugins, instead of requiring that
the module and options are split up. This removed the ability to
override options at the global level, but that seems like reasonable
behavior.

Closes #114