### PR TITLE
use native classes for broccoli-persistent-filter

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,80 +5,75 @@ const Filter = require('broccoli-persistent-filter')
 const Funnel = require('broccoli-funnel')
 const postcss = require('postcss')
 
-PostcssFilter.prototype = Object.create(Filter.prototype)
-PostcssFilter.prototype.constructor = PostcssFilter
+class PostcssFilter extends Filter {
+  constructor (inputNode, _options = {}) {
+    const options = _options || {}
+
+    if (options.exclude || options.include) {
+      inputNode = new Funnel(inputNode, {
+        exclude: options.exclude,
+        include: options.include
+      })
+    }
+
+    super(inputNode, options)
+
+    this.options = options
+    this.warningStream = process.stderr
+  }
+
+  processString (content, relativePath) {
+    const warningStream = this.warningStream
+    const processor = postcss()
+    const opts = assign({
+      from: relativePath,
+      to: relativePath,
+      map: {
+        inline: false,
+        annotation: false
+      },
+      errors: {
+        showSourceCode: true,
+        terminalColors: true
+      }
+    }, this.options)
+
+    if (!opts.plugins || opts.plugins.length < 1) {
+      throw new Error('You must provide at least 1 plugin in the plugin array')
+    }
+
+    opts.plugins.forEach((plugin) => {
+      let pluginInstance
+
+      if (plugin.module) {
+        const pluginOptions = assign(opts, plugin.options || {})
+        pluginInstance = plugin.module(pluginOptions)
+      } else {
+        pluginInstance = plugin
+      }
+
+      processor.use(pluginInstance)
+    })
+
+    return processor.process(content, opts)
+      .then((result) => {
+        result.warnings().forEach(warn => warningStream.write(warn.toString()))
+
+        return result.css
+      })
+      .catch((err) => {
+        if (err.name === 'CssSyntaxError') {
+          if (opts.errors.showSourceCode) {
+            err.message += `\n${err.showSourceCode(opts.errors.terminalColors)}`
+          }
+        }
+
+        throw err
+      })
+  }
+}
 
 PostcssFilter.prototype.extensions = ['css']
 PostcssFilter.prototype.targetExtension = 'css'
-
-function PostcssFilter (inputNode, _options) {
-  const options = _options || {}
-
-  if (!(this instanceof PostcssFilter)) {
-    return new PostcssFilter(inputNode, _options)
-  }
-
-  if (options.exclude || options.include) {
-    inputNode = new Funnel(inputNode, {
-      exclude: options.exclude,
-      include: options.include
-    })
-  }
-
-  Filter.call(this, inputNode, options)
-
-  this.options = options
-  this.warningStream = process.stderr
-}
-
-PostcssFilter.prototype.processString = function (content, relativePath) {
-  const warningStream = this.warningStream
-  const processor = postcss()
-  const opts = assign({
-    from: relativePath,
-    to: relativePath,
-    map: {
-      inline: false,
-      annotation: false
-    },
-    errors: {
-      showSourceCode: true,
-      terminalColors: true
-    }
-  }, this.options)
-
-  if (!opts.plugins || opts.plugins.length < 1) {
-    throw new Error('You must provide at least 1 plugin in the plugin array')
-  }
-
-  opts.plugins.forEach((plugin) => {
-    let pluginInstance
-
-    if (plugin.module) {
-      const pluginOptions = assign(opts, plugin.options || {})
-      pluginInstance = plugin.module(pluginOptions)
-    } else {
-      pluginInstance = plugin
-    }
-
-    processor.use(pluginInstance)
-  })
-
-  return processor.process(content, opts)
-    .then((result) => {
-      result.warnings().forEach(warn => warningStream.write(warn.toString()))
-
-      return result.css
-    })
-    .catch((err) => {
-      if (err.name === 'CssSyntaxError') {
-        if (opts.errors.showSourceCode) {
-          err.message += `\n${err.showSourceCode(opts.errors.terminalColors)}`
-        }
-      }
-
-      throw err
-    })
-}
 
 module.exports = PostcssFilter

--- a/package-lock.json
+++ b/package-lock.json
@@ -901,26 +901,36 @@
       "dev": true
     },
     "async-disk-cache": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/async-disk-cache/-/async-disk-cache-1.3.4.tgz",
-      "integrity": "sha512-qsIvGJ/XYZ5bSGf5vHt2aEQHZnyuehmk/+51rCJhpkZl4LtvOZ+STbhLbdFAJGYO+dLzUT5Bb4nLKqHBX83vhw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/async-disk-cache/-/async-disk-cache-2.1.0.tgz",
+      "integrity": "sha512-iH+boep2xivfD9wMaZWkywYIURSmsL96d6MoqrC94BnGSvXE4Quf8hnJiHGFYhw/nLeIa1XyRaf4vvcvkwAefg==",
       "requires": {
-        "debug": "^2.1.3",
+        "debug": "^4.1.1",
         "heimdalljs": "^0.2.3",
-        "istextorbinary": "2.1.0",
+        "istextorbinary": "^2.5.1",
         "mkdirp": "^0.5.0",
-        "rimraf": "^2.5.3",
-        "rsvp": "^3.0.18",
+        "rimraf": "^3.0.0",
+        "rsvp": "^4.8.5",
         "username-sync": "^1.0.2"
       },
       "dependencies": {
-        "rimraf": {
-          "version": "2.7.1",
-          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
-          "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
           "requires": {
-            "glob": "^7.1.3"
+            "ms": "^2.1.1"
           }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        },
+        "rsvp": {
+          "version": "4.8.5",
+          "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-4.8.5.tgz",
+          "integrity": "sha512-nfMOlASu9OnRJo1mbEk2cz0D56a1MBNrJ7orjRZQG10XDyuvwksKbuXNp6qa+kbn839HwjwhBzhFmdsaEAfauA=="
         }
       }
     },
@@ -934,11 +944,11 @@
       },
       "dependencies": {
         "async": {
-          "version": "2.6.2",
-          "resolved": "https://registry.npmjs.org/async/-/async-2.6.2.tgz",
-          "integrity": "sha512-H1qVYh1MYhEEFLsP97cVKqCGo7KfCyTt6uEWqsTBr9SO84oK9Uwbyd/yCW+6rKJLHksBNUVWZDAjfS+Ccx0Bbg==",
+          "version": "2.6.3",
+          "resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
+          "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
           "requires": {
-            "lodash": "^4.17.11"
+            "lodash": "^4.17.14"
           }
         }
       }
@@ -1043,9 +1053,9 @@
       "dev": true
     },
     "binaryextensions": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/binaryextensions/-/binaryextensions-2.1.2.tgz",
-      "integrity": "sha512-xVNN69YGDghOqCCtA6FI7avYrr02mTJjOgB0/f1VPD3pJC8QEvjTKWc4epDx8AqxxA75NI0QpVM2gPJXUbE4Tg=="
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/binaryextensions/-/binaryextensions-2.3.0.tgz",
+      "integrity": "sha512-nAihlQsYGyc5Bwq6+EsubvANYGExeJKHDO3RjnvwU042fawQTQfM3Kxn7IHUXQOz4bzfwsGYYHGSvXyW4zOGLg=="
     },
     "blank-object": {
       "version": "1.0.2",
@@ -1250,31 +1260,23 @@
       }
     },
     "broccoli-persistent-filter": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/broccoli-persistent-filter/-/broccoli-persistent-filter-2.3.1.tgz",
-      "integrity": "sha512-hVsmIgCDrl2NFM+3Gs4Cr2TA6UPaIZip99hN8mtkaUPgM8UeVnCbxelCvBjUBHo0oaaqP5jzqqnRVvb568Yu5g==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/broccoli-persistent-filter/-/broccoli-persistent-filter-3.1.1.tgz",
+      "integrity": "sha512-gP797MF87JjkcwhGBkE0fhF3aIbGnOF3K3A0iZpQSxtpmSNt+rbNzuqDOmgiKwWpx6v0+APkM5HUA0NiIZpgsQ==",
       "requires": {
-        "async-disk-cache": "^1.2.1",
+        "async-disk-cache": "^2.0.0",
         "async-promise-queue": "^1.0.3",
-        "broccoli-plugin": "^1.0.0",
+        "broccoli-plugin": "^4.0.3",
         "fs-tree-diff": "^2.0.0",
         "hash-for-dep": "^1.5.0",
         "heimdalljs": "^0.2.1",
         "heimdalljs-logger": "^0.1.7",
-        "mkdirp": "^0.5.1",
         "promise-map-series": "^0.2.1",
-        "rimraf": "^2.6.1",
-        "rsvp": "^4.7.0",
+        "rimraf": "^3.0.0",
         "symlink-or-copy": "^1.0.1",
-        "sync-disk-cache": "^1.3.3",
-        "walk-sync": "^1.0.0"
+        "sync-disk-cache": "^2.0.0"
       },
       "dependencies": {
-        "ensure-posix-path": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/ensure-posix-path/-/ensure-posix-path-1.1.1.tgz",
-          "integrity": "sha512-VWU0/zXzVbeJNXvME/5EmLuEj2TauvoaTz6aFYK1Z92JCBlDlZ3Gu0tuGR42kpW1754ywTs+QB0g5TP0oj9Zaw=="
-        },
         "fs-tree-diff": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/fs-tree-diff/-/fs-tree-diff-2.0.1.tgz",
@@ -1286,58 +1288,27 @@
             "path-posix": "^1.0.0",
             "symlink-or-copy": "^1.1.8"
           }
-        },
-        "matcher-collection": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/matcher-collection/-/matcher-collection-1.1.2.tgz",
-          "integrity": "sha512-YQ/teqaOIIfUHedRam08PB3NK7Mjct6BvzRnJmpGDm8uFXpNr1sbY4yuflI5JcEs6COpYA0FpRQhSDBf1tT95g==",
-          "requires": {
-            "minimatch": "^3.0.2"
-          }
-        },
-        "rimraf": {
-          "version": "2.7.1",
-          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
-          "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
-          "requires": {
-            "glob": "^7.1.3"
-          }
-        },
-        "rsvp": {
-          "version": "4.8.5",
-          "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-4.8.5.tgz",
-          "integrity": "sha512-nfMOlASu9OnRJo1mbEk2cz0D56a1MBNrJ7orjRZQG10XDyuvwksKbuXNp6qa+kbn839HwjwhBzhFmdsaEAfauA=="
-        },
-        "walk-sync": {
-          "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/walk-sync/-/walk-sync-1.1.4.tgz",
-          "integrity": "sha512-nowc9thB/Jg0KW4TgxoRjLLYRPvl3DB/98S89r4ZcJqq2B0alNcKDh6pzLkBSkPMzRSMsJghJHQi79qw0YWEkA==",
-          "requires": {
-            "@types/minimatch": "^3.0.3",
-            "ensure-posix-path": "^1.1.0",
-            "matcher-collection": "^1.1.1"
-          }
         }
       }
     },
     "broccoli-plugin": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/broccoli-plugin/-/broccoli-plugin-1.3.0.tgz",
-      "integrity": "sha1-vucEqOQtoIy1jlE6qkNu+38O8e4=",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/broccoli-plugin/-/broccoli-plugin-4.0.3.tgz",
+      "integrity": "sha512-CtAIEYq5K+4yQv8c/BHymOteuyjDAJfvy/asu4LudIWcMSS7dTn3yGI5gNBkwHG+qlRangYkHJNVAcDZMQbSVQ==",
       "requires": {
+        "broccoli-node-api": "^1.6.0",
+        "broccoli-output-wrapper": "^3.2.1",
+        "fs-merger": "^3.1.0",
         "promise-map-series": "^0.2.1",
         "quick-temp": "^0.1.3",
-        "rimraf": "^2.3.4",
-        "symlink-or-copy": "^1.1.8"
+        "rimraf": "^3.0.0",
+        "symlink-or-copy": "^1.3.0"
       },
       "dependencies": {
-        "rimraf": {
-          "version": "2.7.1",
-          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
-          "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
-          "requires": {
-            "glob": "^7.1.3"
-          }
+        "symlink-or-copy": {
+          "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/symlink-or-copy/-/symlink-or-copy-1.3.1.tgz",
+          "integrity": "sha512-0K91MEXFpBUaywiwSSkmKjnGcasG/rVBXFLJz5DrgGabpYD6N+3yZrfD6uUIfpuTu65DZLHi7N8CizHc07BPZA=="
         }
       }
     },
@@ -1929,9 +1900,20 @@
       }
     },
     "editions": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/editions/-/editions-1.3.4.tgz",
-      "integrity": "sha512-gzao+mxnYDzIysXKMQi/+M1mjy/rjestjg6OPoYTtI+3Izp23oiGZitsl9lPDPiTGXbcSIk1iJWhliSaglxnUg=="
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/editions/-/editions-2.3.1.tgz",
+      "integrity": "sha512-ptGvkwTvGdGfC0hfhKg0MT+TRLRKGtUiWGBInxOm5pz7ssADezahjCUaYuZ8Dr+C05FW0AECIIPt4WBxVINEhA==",
+      "requires": {
+        "errlop": "^2.0.0",
+        "semver": "^6.3.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
+        }
+      }
     },
     "ee-first": {
       "version": "1.1.1",
@@ -1973,6 +1955,11 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ensure-posix-path/-/ensure-posix-path-1.1.1.tgz",
       "integrity": "sha512-VWU0/zXzVbeJNXvME/5EmLuEj2TauvoaTz6aFYK1Z92JCBlDlZ3Gu0tuGR42kpW1754ywTs+QB0g5TP0oj9Zaw=="
+    },
+    "errlop": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/errlop/-/errlop-2.2.0.tgz",
+      "integrity": "sha512-e64Qj9+4aZzjzzFpZC7p5kmm/ccCrbLhAJplhsDXQFs87XTsXwOpH4s1Io2s90Tau/8r2j9f4l/thhDevRjzxw=="
     },
     "error-ex": {
       "version": "1.3.1",
@@ -4086,13 +4073,13 @@
       }
     },
     "istextorbinary": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/istextorbinary/-/istextorbinary-2.1.0.tgz",
-      "integrity": "sha1-2+0qb1G+L3R1to+JRlgRFBt1iHQ=",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/istextorbinary/-/istextorbinary-2.6.0.tgz",
+      "integrity": "sha512-+XRlFseT8B3L9KyjxxLjfXSLMuErKDsd8DBNrsaxoViABMEZlOSCstwmw0qpoFX3+U6yWU1yhLudAe6/lETGGA==",
       "requires": {
-        "binaryextensions": "1 || 2",
-        "editions": "^1.1.1",
-        "textextensions": "1 || 2"
+        "binaryextensions": "^2.1.2",
+        "editions": "^2.2.0",
+        "textextensions": "^2.5.0"
       }
     },
     "iterate-iterator": {
@@ -6283,24 +6270,42 @@
       "integrity": "sha512-W31+GLiBmU/ZR02Ii0mVZICuNEN9daZ63xZMPDsYgPgNjMtg+atqLEGI7PPI936jYSQZxoLb/63xos8Adrx4Eg=="
     },
     "sync-disk-cache": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/sync-disk-cache/-/sync-disk-cache-1.3.3.tgz",
-      "integrity": "sha512-Kp7DFemXDPRUbFW856CKamtX7bJuThZPa2dwnK2RfNqMew7Ah8xDc52SdooNlfN8oydDdDHlBPLsXTrtmA7HKw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/sync-disk-cache/-/sync-disk-cache-2.1.0.tgz",
+      "integrity": "sha512-vngT2JmkSapgq0z7uIoYtB9kWOOzMihAAYq/D3Pjm/ODOGMgS4r++B+OZ09U4hWR6EaOdy9eqQ7/8ygbH3wehA==",
       "requires": {
-        "debug": "^2.1.3",
-        "heimdalljs": "^0.2.3",
+        "debug": "^4.1.1",
+        "heimdalljs": "^0.2.6",
         "mkdirp": "^0.5.0",
-        "rimraf": "^2.2.8",
+        "rimraf": "^3.0.0",
         "username-sync": "^1.0.2"
       },
       "dependencies": {
-        "rimraf": {
-          "version": "2.7.1",
-          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
-          "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
           "requires": {
-            "glob": "^7.1.3"
+            "ms": "^2.1.1"
           }
+        },
+        "heimdalljs": {
+          "version": "0.2.6",
+          "resolved": "https://registry.npmjs.org/heimdalljs/-/heimdalljs-0.2.6.tgz",
+          "integrity": "sha512-o9bd30+5vLBvBtzCPwwGqpry2+n0Hi6H1+qwt6y+0kwRHGGF8TFIhJPmnuM0xO97zaKrDZMwO/V56fAnn8m/tA==",
+          "requires": {
+            "rsvp": "~3.2.1"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        },
+        "rsvp": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-3.2.1.tgz",
+          "integrity": "sha1-B8tKXfJa3Z6Cbrxn3Mn9idsn2Eo="
         }
       }
     },
@@ -6362,9 +6367,9 @@
       "dev": true
     },
     "textextensions": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/textextensions/-/textextensions-2.4.0.tgz",
-      "integrity": "sha512-qftQXnX1DzpSV8EddtHIT0eDDEiBF8ywhFYR2lI9xrGtxqKN+CvLXhACeCIGbCpQfxxERbrkZEFb8cZcDKbVZA=="
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/textextensions/-/textextensions-2.6.0.tgz",
+      "integrity": "sha512-49WtAWS+tcsy93dRt6P0P3AMD2m5PvXRhuEA0kaXos5ZLlujtYmpmFsB+QvWUSxE1ZsstmYXfQ7L40+EcQgpAQ=="
     },
     "through": {
       "version": "2.3.8",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   "homepage": "https://github.com/jeffjewiss/broccoli-postcss",
   "dependencies": {
     "broccoli-funnel": "^3.0.0",
-    "broccoli-persistent-filter": "^2.1.0",
+    "broccoli-persistent-filter": "^3.1.1",
     "minimist": ">=1.2.5",
     "object-assign": "^4.1.1",
     "postcss": "^7.0.5"

--- a/test/index.js
+++ b/test/index.js
@@ -6,7 +6,7 @@ const assert = require('assert')
 const fs = require('fs')
 const path = require('path')
 const broccoli = require('broccoli')
-const postcssFilter = require('../')
+const PostcssFilter = require('../')
 const postcss = require('postcss')
 const rimraf = require('rimraf')
 const glob = require('glob')
@@ -50,9 +50,9 @@ afterEach(function () {
 })
 
 it('should process css', function () {
-  const outputTree = postcssFilter('fixture/success', { plugins: basicPluginSet, map: true })
+  const outputTree = new PostcssFilter('fixture/success', { plugins: basicPluginSet, map: true })
   const builder = new broccoli.Builder(outputTree) // eslint-disable-line no-new
-  postcssFilter.warningStream = warningStreamStub
+  PostcssFilter.warningStream = warningStreamStub
 
   return builder.build().then(function () {
     const content = fs.readFileSync(path.join(builder.outputPath, 'fixture.css'), 'utf8')
@@ -63,9 +63,9 @@ it('should process css', function () {
 })
 
 it('should only include css from include patterns', function () {
-  const outputTree = postcssFilter('fixture/include', { plugins: basicPluginSet, map: true, include: ['fixture.css'] })
+  const outputTree = new PostcssFilter('fixture/include', { plugins: basicPluginSet, map: true, include: ['fixture.css'] })
   const builder = new broccoli.Builder(outputTree) // eslint-disable-line no-new
-  postcssFilter.warningStream = warningStreamStub
+  PostcssFilter.warningStream = warningStreamStub
 
   return builder.build().then(function () {
     const fixture = fs.readFileSync(path.join(builder.outputPath, 'fixture.css'), 'utf8')
@@ -85,9 +85,9 @@ it('should only include css from include patterns', function () {
 })
 
 it('should not include css from exclude patterns', function () {
-  const outputTree = postcssFilter('fixture/exclude', { plugins: basicPluginSet, map: true, exclude: ['missing.css'] })
+  const outputTree = new PostcssFilter('fixture/exclude', { plugins: basicPluginSet, map: true, exclude: ['missing.css'] })
   const builder = new broccoli.Builder(outputTree) // eslint-disable-line no-new
-  postcssFilter.warningStream = warningStreamStub
+  PostcssFilter.warningStream = warningStreamStub
 
   return builder.build().then(function () {
     const fixture = fs.readFileSync(path.join(builder.outputPath, 'fixture.css'), 'utf8')
@@ -107,7 +107,7 @@ it('should not include css from exclude patterns', function () {
 })
 
 it('should expose warnings', function () {
-  const outputTree = postcssFilter('fixture/warning', { plugins: testWarnPluginSet })
+  const outputTree = new PostcssFilter('fixture/warning', { plugins: testWarnPluginSet })
   const builder = new broccoli.Builder(outputTree) // eslint-disable-line no-new
   outputTree.warningStream = warningStreamStub
 
@@ -119,7 +119,7 @@ it('should expose warnings', function () {
 })
 
 it('should expose syntax errors', function () {
-  const outputTree = postcssFilter('fixture/syntax-error', {
+  const outputTree = new PostcssFilter('fixture/syntax-error', {
     errors: {
       showSourceCode: true,
       terminalColors: false
@@ -144,7 +144,7 @@ it('should expose syntax errors', function () {
 })
 
 it('should expose non-syntax errors', function () {
-  const outputTree = postcssFilter('fixture/missing-file', { plugins: testWarnPluginSet })
+  const outputTree = new PostcssFilter('fixture/missing-file', { plugins: testWarnPluginSet })
   let count = 0
 
   outputTree.warningStream = warningStreamStub
@@ -161,7 +161,7 @@ it('should expose non-syntax errors', function () {
 })
 
 it('should throw an error if there is not at least 1 plugin', function () {
-  const outputTree = postcssFilter('fixture/success', {})
+  const outputTree = new PostcssFilter('fixture/success', {})
   const builder = new broccoli.Builder(outputTree) // eslint-disable-line no-new
   let count = 0
 
@@ -184,14 +184,14 @@ it('supports an array of plugin instances', function () {
   const basicOptions = basicPluginSet[0].options
   const pluginInstance = basicPlugin(basicOptions)
 
-  const outputTree = postcssFilter('fixture/success', {
+  const outputTree = new PostcssFilter('fixture/success', {
     plugins: [
       pluginInstance
     ],
     map: true
   })
   const builder = new broccoli.Builder(outputTree) // eslint-disable-line no-new
-  postcssFilter.warningStream = warningStreamStub
+  PostcssFilter.warningStream = warningStreamStub
 
   return builder.build().then(function () {
     const content = fs.readFileSync(path.join(builder.outputPath, 'fixture.css'), 'utf8')


### PR DESCRIPTION
👋 I saw you mention in https://github.com/jeffjewiss/ember-cli-postcss/issues/659 that to support `postcss@8`, both `broccoli-postcss` and `broccoli-postcss-single` need to be upgraded first..

I had a look and saw `broccoli-persistent-filter` also needed updating, so I've started with that.

Hopefully this helps 😄 