### PR TITLE
GitHub action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         node: [
-          13,
+          14,
           12,
           10
         ]
@@ -17,10 +17,10 @@ jobs:
       - name: Check out a copy of the repo
         uses: actions/checkout@v2
 
-      - name: Use Node.js ${{ matrix.node-version }}
+      - name: Use Node.js ${{ matrix.node }}
         uses: actions/setup-node@v1
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version: ${{ matrix.node }}
 
       - name: Install Dependencies
         run: npm ci

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,14 @@ jobs:
         with:
           node-version: ${{ matrix.node }}
 
+      - name: Cache node_modules
+        uses: actions/cache@v2
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-
+
       - name: Install Dependencies
         run: npm ci
 

--- a/.nycrc.json
+++ b/.nycrc.json
@@ -1,0 +1,6 @@
+{
+	"reporter": [
+		"lcov",
+		"text-summary"
+	]
+}


### PR DESCRIPTION
Fixes usage of node version

Adds `.nycrc.json` which includes the `lcov` reporter for `nyc`

Also adds a cache for node_modules 🐎 